### PR TITLE
Fix for correctly getting a PR comments instead of the review comments

### DIFF
--- a/llm_fragments_github.py
+++ b/llm_fragments_github.py
@@ -113,7 +113,11 @@ def github_issue_loader(argument: str, noun="issues") -> llm.Fragment:
     issue = issue_resp.json()
 
     # 2. All comments (pagination)
-    comments = _get_all_pages(client, f"{issue_api}/comments?per_page=100")
+    comments_api_url = issue.get("comments_url")
+
+    comments = []
+    if comments_api_url:
+        comments = _get_all_pages(client, f"{comments_api_url}?per_page=100")
 
     # 3. Markdown
     raw_md = _to_markdown(issue, comments)

--- a/tests/test_fragments_github.py
+++ b/tests/test_fragments_github.py
@@ -74,7 +74,7 @@ def test_github_pr_loader(argument):
     )
     assert (
         str(fragments[0])
-        == "# Example PR\n\n*Posted by @simonw*\n\nThis is an example PR.\n"
+        == "# Example PR\n\n*Posted by @simonw*\n\nThis is an example PR.\n\n---\n\n### Comment by @simonw\n\nIt has one comment.\n\n---\n"
     )
     assert (
         fragments[1].source


### PR DESCRIPTION
## Problem

https://github.com/simonw/llm-fragments-github/pull/9 implements an initial version of what is described in https://github.com/simonw/llm-fragments-github/issues/7

However the implementation assumes that to get a specific PR comments the code should use the `{owner}/{repo}/pulls/comments` endpoint while when getting comments for non-PR issues it uses `{owner}/{repo}/issues/comments` [PR diff ref](https://github.com/simonw/llm-fragments-github/pull/9/files#diff-f10b296783d20421ab4619e7616254e70cc15935066578a9d8493461964542b3R125)

This assumption is somewhat wrong: for a PR there are 2 different endpoints that can be used to get comments 
- `{owner}/{repo}/issues/comments` returns generic comments on the PR
- `{owner}/{repo}/pulls/comments` returns **review** comments that are practically comments left inline (those that target specific lines of the code that is being changed by the PR)

The current implementation is only returning the latter kind of comments.
Notably the test for it is also wrong:
https://github.com/simonw/llm-fragments-github/blob/50b7d923211efe21de9fc0d00077b6544c19143e/tests/test_fragments_github.py#L77 does not include the `It has one comment.` comment on https://github.com/simonw/test-repo-for-llm-fragments-github/pull/2


## Solution 
The first request made to get a PR metadata includes both a `comments_url` and a `review_comments_url` attributes that contain the specific endpoints to use for each kind of comments.
This PR changes the code to use the url from the `comments_url` attribute, which is also returned when requesting metadata for non-PR issues, so that it can get the main comments in both cases.

This PR **does not** include changes to also retrieve `review_comments_url` comments. Those are a bit more complex to deal with because of the fact that they include information about which specific lines of code they are referencing and the implementation would have to also deal with how to present them in markdown. I still think it would be good if this was implemented, but it probably makes sense to do it in a separate PR (for reference my rough bash script is doing it in a somewhat naive way https://gist.github.com/giuli007/c0ad2a78a538d11dbd07a9ef93f714ae )