### PR TITLE
GitHub pr loader include review comments

### DIFF
--- a/llm_fragments_github.py
+++ b/llm_fragments_github.py
@@ -113,7 +113,11 @@ def github_issue_loader(argument: str, noun="issues") -> llm.Fragment:
     issue = issue_resp.json()
 
     # 2. All comments (pagination)
-    comments = _get_all_pages(client, f"{issue_api}/comments?per_page=100")
+    comments_api_url = issue.get("comments_url")
+
+    comments = []
+    if comments_api_url:
+        comments = _get_all_pages(client, f"{comments_api_url}?per_page=100")
 
     # 3. Markdown
     raw_md = _to_markdown(issue, comments)

--- a/llm_fragments_github.py
+++ b/llm_fragments_github.py
@@ -119,8 +119,18 @@ def github_issue_loader(argument: str, noun="issues") -> llm.Fragment:
     if comments_api_url:
         comments = _get_all_pages(client, f"{comments_api_url}?per_page=100")
 
-    # 3. Markdown
-    raw_md = _to_markdown(issue, comments)
+    # 3. Review comments, if any
+    review_comments = []
+    if noun == "pulls":
+        review_comments_api_url = (
+            f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}/comments"
+        )
+        review_comments = _get_all_pages(
+            client, f"{review_comments_api_url}?per_page=100"
+        )
+
+    # 4. Markdown
+    raw_md = _to_markdown(issue, comments, review_comments)
 
     # 4. Expand any blob URLs into inline code
     markdown = _expand_code_references(raw_md, client)
@@ -221,22 +231,59 @@ def _get_all_pages(client: httpx.Client, url: str) -> List[dict]:
     return items
 
 
-def _to_markdown(issue: dict, comments: List[dict]) -> str:
-    md: List[str] = []
-    md.append(f"# {issue['title']}\n")
-    md.append(f"*Posted by @{issue['user']['login']}*\n")
+def _to_markdown(
+    issue: dict, comments: List[dict], review_comments: List[dict] | None = None
+) -> str:
+    md_parts: List[str] = []
+    md_parts.append(f"# {issue['title']}")
+    md_parts.append(f"*Posted by @{issue['user']['login']}*")
     if issue.get("body"):
-        md.append(issue["body"] + "\n")
+        md_parts.append(issue["body"])
 
     if comments:
-        md.append("---\n")
+        md_parts.append("---")
         for c in comments:
-            md.append(f"### Comment by @{c['user']['login']}\n")
+            md_parts.append(f"### Comment by @{c['user']['login']}")
             if c.get("body"):
-                md.append(c["body"] + "\n")
-            md.append("---\n")
+                md_parts.append(c["body"])
+            md_parts.append("---")
 
-    return "\n".join(md).rstrip() + "\n"
+    if review_comments:
+        review_md_parts = []
+        review_md_parts.append("## Review comments\n")
+
+        # Group comments into threads
+        threads = {}
+        for comment in review_comments:
+            thread_id = comment.get("in_reply_to_id") or comment["id"]
+            if thread_id not in threads:
+                threads[thread_id] = []
+            threads[thread_id].append(comment)
+
+        # Then group threads by file path
+        threads_by_file = {}
+        for thread_id, thread_comments in threads.items():
+            # All comments in a thread have the same path
+            path = thread_comments[0]["path"]
+            if path not in threads_by_file:
+                threads_by_file[path] = []
+            threads_by_file[path].append(thread_comments)
+
+        for path, path_threads in threads_by_file.items():
+            review_md_parts.append(f"### On file `{path}`\n")
+            for thread in path_threads:
+                # The first comment is the head of the thread
+                first_comment = thread[0]
+                review_md_parts.append(f"```diff\n{first_comment['diff_hunk']}\n```\n")
+                for comment in thread:
+                    review_md_parts.append(
+                        f"#### Comment by @{comment['user']['login']}\n\n{comment['body']}\n"
+                    )
+                review_md_parts.append("---")
+
+        md_parts.append("\n".join(review_md_parts))
+
+    return "\n\n".join(md_parts).rstrip() + "\n"
 
 
 def _expand_code_references(markdown: str, client: httpx.Client) -> str:

--- a/llm_fragments_github.py
+++ b/llm_fragments_github.py
@@ -241,9 +241,9 @@ def _to_markdown(
         md_parts.append(issue["body"])
 
     if comments:
-        md_parts.append("---")
+        md_parts.append("## Comments")
         for c in comments:
-            md_parts.append(f"### Comment by @{c['user']['login']}")
+            md_parts.append(f"#### Comment by @{c['user']['login']}")
             if c.get("body"):
                 md_parts.append(c["body"])
             md_parts.append("---")

--- a/tests/test_fragments_github.py
+++ b/tests/test_fragments_github.py
@@ -74,7 +74,7 @@ def test_github_pr_loader(argument):
     )
     assert (
         str(fragments[0])
-        == "# Example PR\n\n*Posted by @simonw*\n\nThis is an example PR.\n"
+        == "# Example PR\n\n*Posted by @simonw*\n\nThis is an example PR.\n\n---\n\n### Comment by @simonw\n\nIt has one comment.\n\n---\n"
     )
     assert (
         fragments[1].source

--- a/tests/test_fragments_github.py
+++ b/tests/test_fragments_github.py
@@ -36,10 +36,10 @@ def test_github_issue_loader(argument):
         "# Example issue\n\n"
         "*Posted by @simonw*\n\n"
         "Has a description.\n\n"
-        "---\n\n"
-        "### Comment by @simonw\n\n"
+        "## Comments\n\n"
+        "#### Comment by @simonw\n\n"
         "Comment 1.\n\n"
-        "---\n\n### Comment by @simonw\n\n"
+        "---\n\n#### Comment by @simonw\n\n"
         "Comment 2.\n\n"
         "---\n"
     )
@@ -74,7 +74,7 @@ def test_github_pr_loader(argument):
     )
     assert (
         str(fragments[0])
-        == "# Example PR\n\n*Posted by @simonw*\n\nThis is an example PR.\n\n---\n\n### Comment by @simonw\n\nIt has one comment.\n\n---\n"
+        == "# Example PR\n\n*Posted by @simonw*\n\nThis is an example PR.\n\n## Comments\n\n#### Comment by @simonw\n\nIt has one comment.\n\n---\n"
     )
     assert (
         fragments[1].source
@@ -111,8 +111,8 @@ def test_github_pr_loader_review_comments(argument):
         "# A test PR\n\n"
         "*Posted by @giuli007*\n\n"
         "PR test description\n\n"
-        "---\n\n"
-        "### Comment by @giuli007\n\n"
+        "## Comments\n\n"
+        "#### Comment by @giuli007\n\n"
         "Comment 1\n\n"
         "---\n\n"
         "## Review comments\n\n"

--- a/tests/test_fragments_github.py
+++ b/tests/test_fragments_github.py
@@ -93,6 +93,85 @@ def test_github_pr_loader(argument):
     )
 
 
+@pytest.mark.parametrize(
+    "argument",
+    (
+        "giuli007/llm-fragments-github/1",
+        "https://github.com/giuli007/llm-fragments-github/pull/1",
+    ),
+)
+def test_github_pr_loader_review_comments(argument):
+    fragments = github_pr_loader(argument)
+    assert len(fragments) == 2
+    assert (
+        fragments[0].source
+        == "https://github.com/giuli007/llm-fragments-github/pull/1"
+    )
+    expected_markdown = (
+        "# A test PR\n\n"
+        "*Posted by @giuli007*\n\n"
+        "PR test description\n\n"
+        "---\n\n"
+        "### Comment by @giuli007\n\n"
+        "Comment 1\n\n"
+        "---\n\n"
+        "## Review comments\n\n"
+        "### On file `llm_fragments_github.py`\n\n"
+        "```diff\n"
+        "@@ -22,7 +22,6 @@ def github_loader(argument: str) -> List[llm.Fragment]:\n"
+        " \n"
+        "     Argument is a GitHub repository URL or username/repository\n"
+        '     """\n'
+        "-    # Normalize the repository argument\n"
+        "```\n\n"
+        "#### Comment by @giuli007\n\n"
+        "Inline comment 1\n\n"
+        "#### Comment by @giuli007\n\n"
+        "Inline comment 3\n\n"
+        "---\n"
+        "```diff\n"
+        "@@ -183,6 +182,8 @@ def _parse_argument(arg: str) -> Tuple[str, str, int]:\n"
+        " \n"
+        " \n"
+        " def _github_client() -> httpx.Client:\n"
+        "+    # creates client\n"
+        "+    # and use token if set\n"
+        "```\n\n"
+        "#### Comment by @giuli007\n\n"
+        "Inline comment 2\n\n"
+        "---\n"
+    )
+    assert str(fragments[0]) == expected_markdown
+    assert (
+        fragments[1].source
+        == "https://api.github.com/repos/giuli007/llm-fragments-github/pulls/1.diff"
+    )
+    expected_diff = (
+        "diff --git a/llm_fragments_github.py b/llm_fragments_github.py\n"
+        "index 371e058..a4b4e65 100644\n"
+        "--- a/llm_fragments_github.py\n"
+        "+++ b/llm_fragments_github.py\n"
+        "@@ -22,7 +22,6 @@ def github_loader(argument: str) -> List[llm.Fragment]:\n"
+        " \n"
+        "     Argument is a GitHub repository URL or username/repository\n"
+        '     """\n'
+        "-    # Normalize the repository argument\n"
+        '     if not argument.startswith(("http://", "https://")):\n'
+        "         # Assume format is username/repo\n"
+        '         repo_url = f"https://github.com/{argument}.git"\n'
+        "@@ -183,6 +182,8 @@ def _parse_argument(arg: str) -> Tuple[str, str, int]:\n"
+        " \n"
+        " \n"
+        " def _github_client() -> httpx.Client:\n"
+        "+    # creates client\n"
+        "+    # and use token if set\n"
+        '     headers = {"Accept": "application/vnd.github+json"}\n'
+        '     token = os.getenv("GITHUB_TOKEN")\n'
+        "     if token:\n"
+    )
+    assert str(fragments[1]) == expected_diff
+
+
 def test_github_issue_with_code_references(httpx_mock, monkeypatch):
     # Ensure we hit the raw.githubusercontent.com branch
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
@@ -115,6 +194,7 @@ def test_github_issue_with_code_references(httpx_mock, monkeypatch):
             "title": "Test Issue",
             "user": {"login": "alice"},
             "body": issue_body,
+            "comments_url": f"https://api.github.com/repos/{owner}/{repo}/issues/{number}/comments",
         },
     )
 


### PR DESCRIPTION
This PR is a further enhancement from the unmerged https://github.com/simonw/llm-fragments-github/pull/13 whose changes are also included here (first commit). If this gets accepted/merged then #13 can be closed.

# Problem
https://github.com/simonw/llm-fragments-github/pull/9 implements an initial version of what is described in https://github.com/simonw/llm-fragments-github/issues/7 but it has some issues described in https://github.com/simonw/llm-fragments-github/pull/13

tl:dr the current implementation for getting PR fragments
- tries to fetch review comments instead of comments
- does not try to format review comments as discussions on specific file and line changes

# Solution

This PR implements 
- correctly fetching both comments and review comments form a PR: like explained in PR#13 by leveraging the `comments_url` and `review_comments_url` metadata returned by github instead of hardcoding their urls
- formatting both types of comments as Markdown
- slightly change the formatting of comments for consistency: adding a `## Comments` heading and changing the heading size of normal comments for consistency
- a new test to validate the review comments fetching and formatting: I did this by pointing at a PR on my own fork https://github.com/giuli007/llm-fragments-github/pull/1 which I assume we might want to change and actually point at a PR in https://github.com/simonw/test-repo-for-llm-fragments-github instead (I didn't want to create or change the existing one there without Simon's approval first)

I kept things in 3 separate commits for ease of review.

To have a feel for what the resulting fragment would look like see this https://gist.github.com/giuli007/3163c5306c0f5262d95674d281cafeab (generated with `python -c "from llm_fragments_github import github_pr_loader; import sys; [print(f) for f in github_pr_loader(sys.argv[1])[:1]]" https://github.com/giuli007/llm-fragments-github/pull/1 | gh gist create --public -f giuli007_llm-fragments_github_pull_1.md -` reported here for convenience)

# Verification

Ran the tests but also tried the plugin locally

```
$ llm -f pr:https://github.com/giuli007/llm-fragments-github/pull/1 -s 'summarize the pr'
This is a test pull request submitted by @giuli007. The purpose of the PR is to test changes and includes a description labeled as a "PR test description."

**Comments and Feedback:**
- The author, @giuli007, has left several inline comments, marked as "Inline comment" 1 through 3, providing additional information or notes related to specific code sections.

**Code Changes Highlight:**
1. The function `github_loader` in `llm_fragments_github.py` has undergone changes:
   - A comment line for normalizing the repository argument has been removed.
   - An assumption about the format when a URL does not start with "http://" or "https://" is addressed by constructing the repository URL.

2. In the `_github_client` function, comments were added to indicate that the client is created and a token is used if set, improving code clarity.

Overall, the pull request involves minor code adjustments and comments, with a focus on testing and refining the script in question.
```

and checked the fragment in question with
`llm logs --cid 01jybxqys157nwamjq8rpn95xn --expand`

---

As noted I had to make some calls about the formatting of things. I am happy to discuss these changes further and iterate on them
